### PR TITLE
Fix syntax error and add missing import

### DIFF
--- a/request.go
+++ b/request.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 
 	"github.com/aws/aws-lambda-go/events"
@@ -19,7 +20,7 @@ func newHTTPRequest(ctx context.Context, event events.APIGatewayProxyRequest) (*
 	}
 	u := url.URL{
 		Host:     event.Headers["Host"],
-		Path:     path.Join("/", event.PathParameters["proxy"]),,
+		Path:     path.Join("/", event.PathParameters["proxy"]),
 		RawQuery: params.Encode(),
 	}
 	// Handle base64 encoded body.


### PR DESCRIPTION
There is currently a syntax error in `request.go` due to an extra trailing comma, meaning that this package does not currently compile.

This PR fixes it.